### PR TITLE
Adds a couple of changes to the checkstyle.sh file

### DIFF
--- a/checkstyle.sh
+++ b/checkstyle.sh
@@ -17,7 +17,7 @@ while getopts ":a" opt; do
 				filenameNoExtension=${filename%.*}
 				dirpath=${file%/*}
 				cd $dirpath
-				if javac $filename; then
+				if javac -Xlint $filename; then
 					printf "Compiled Successfully\n\n"
 				else
 					echo "Failed to compile"
@@ -43,7 +43,7 @@ then
 	if [[ $dirpath == $filename ]]; then
     	cd $dirpath
 	fi
-	if javac $filename; then
+	if javac -Xlint $filename; then
 	    printf "Compiled Successfully\n\n"
 	else
 	    echo "Failed to compile"

--- a/checkstyle.sh
+++ b/checkstyle.sh
@@ -40,7 +40,9 @@ then
 	filename=${file##*/}
 	filenameNoExtension=${filename%.*}
 	dirpath=${file%/*}
-	cd $dirpath
+	if [[ $dirpath == $filename ]]; then
+    	cd $dirpath
+	fi
 	if javac $filename; then
 	    printf "Compiled Successfully\n\n"
 	else


### PR DESCRIPTION
This makes the javac command also print out java warnings and on the single file version of the command to not emit an error message if the path to the file is in the current directory.

Example:
checkstyle Test.java no longer will say that Test.java is no longer a valid directory